### PR TITLE
File description: specify endpoint timeout

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -122,6 +122,7 @@ Hours and dates of operation SHOULD be published even in cases where services ar
 
 * Files are distributed as individual HTTP endpoints.
     * All endpoints MUST use HTTPS
+    * All endpoints MUST respond to HTTP requests in less than 5 seconds
     * REQUIRED files MUST NOT 404. They MUST return a properly formatted JSON file as defined in [Output Format](#output-format).
     * OPTIONAL files MAY 404. A 404 of an OPTIONAL file SHOULD NOT be considered an error.
 

--- a/gbfs.md
+++ b/gbfs.md
@@ -122,7 +122,7 @@ Hours and dates of operation SHOULD be published even in cases where services ar
 
 * Files are distributed as individual HTTP endpoints.
     * All endpoints MUST use HTTPS
-    * All endpoints MUST respond to HTTP requests in less than 5 seconds
+    * All endpoints SHOULD respond to HTTP requests in less than 1 second
     * REQUIRED files MUST NOT 404. They MUST return a properly formatted JSON file as defined in [Output Format](#output-format).
     * OPTIONAL files MAY 404. A 404 of an OPTIONAL file SHOULD NOT be considered an error.
 


### PR DESCRIPTION
#### **What problem does your proposal solve? Please begin with the relevant issue number. If there is no existing issue, please also describe alternative solutions you have considered.**

Some GBFS feeds respond slowly to HTTP requests, making it difficult for consumers who must increase timeouts or adopt retry strategies.

#### **What is the proposal?**

Specify that HTTP responses SHOULD happen in under 1 second. Consumers should be able to set 1 second as a timeout for HTTP requests.

#### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure

#### **Which files are affected by this change?**

All