### PR TITLE
Fix vehicle availability example (Datetime)

### DIFF
--- a/gbfs.md
+++ b/gbfs.md
@@ -1178,11 +1178,11 @@ Field Name | REQUIRED | Type | Defines
         ],
         "availabilities": [
           {
-            "from": "2024-12-24T08:15Z",
-            "until": "2024-12-24T09:15Z"
+            "from": "2024-12-24T08:15:00Z",
+            "until": "2024-12-24T09:15:00Z"
           },
           {
-            "from": "2024-12-25T10:30Z"
+            "from": "2024-12-25T10:30:00Z"
           }
         ]
       },
@@ -1192,7 +1192,7 @@ Field Name | REQUIRED | Type | Defines
         "station_id": "86",
         "availabilities": [
           {
-            "from": "2024-12-24T08:45Z"
+            "from": "2024-12-24T08:45:00Z"
           }
         ]
       }


### PR DESCRIPTION
### Context
The endpoint `vehicle_availability.json` was added in [v3.1-RC2](https://github.com/MobilityData/gbfs/releases/tag/v3.1-RC2) but there was a typo in the example.

### What's Changed
Fixed the values in the example of the new endpoint `vehicle_availability.json` to be Datetime.

Before: "2024-12-24T08:15Z"
After: "2024-12-24T08:15:00Z" (added missing seconds :00 before Z)