### PR TITLE
Update Bilbaobizi feed URL

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -437,7 +437,7 @@ ES,BiciMAD (unofficial),Madrid,bici_madrid,https://www.bicimad.com/,https://gbfs
 ES,BiciMislata Mislata,Mislata,nextbike_ad,https://bicimislata.mibisivalencia.es/en/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ad/gbfs.json,2.3,,,
 ES,Bicing,Barcelona,bike_barcelona,https://www.bicing.barcelona/,https://barcelona-sp.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,,,
 ES,BiciPalma,Palma,nextbike_ea,https://www.bicipalma.com/es/palma/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_ea/gbfs.json,2.3,,,
-ES,Bilbaobizi (Bilbao),Bilbao,nextbike_bo,https://www.bilbaobizi.bilbao.eus/eu/bilbao/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_bo/gbfs.json,2.3,,,
+ES,Bilbaobizi,Bilbao,bilbao,https://www.lyfturbansolutions.com/cities/bilbao-bike-share,https://bilbao.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,,,
 ES,Bird Madrid,Madrid,bird-madrid,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/madrid/gbfs.json,1.1 ; 2.3,,,
 ES,Bird Zaragoza,Zaragoza,bird zaragoza,https://www.bird.co,https://mds.bird.co/gbfs/v2/public/zaragoza/gbfs.json,1.1 ; 2.3,,,
 ES,Bizi,Zaragoza,zaragoza,https://bizi.zaragoza.es,https://zaragoza.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,,,


### PR DESCRIPTION
Fixes https://github.com/MobilityData/gbfs/issues/768

## Context
Bilbaobizi migrated from nextbike to Lyft Urban Solutions in Spring 2025 (see [article](https://www.lyfturbansolutions.com/blog/2025/06/bilbao-gets-a-major-micromobility-boost-with-the-launch-of-bilbaobizi)).

## What's Changed
Updated the system_id, website URL and feed URL for Bilbaobizi (now provided by Lyft Urban Solutions).