### PR TITLE
Revert "Add Lime Seattle v1.0 feed"

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -1196,7 +1196,7 @@ US,Lime Oakland,"Oakland, CA",lime_oakland,https://www.li.me/,https://data.lime.
 US,Lime Portland,"Portland, OR",lime_portland,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/portland/gbfs.json,2.2,,,
 US,Lime San Francisco,"San Francisco, CA",lime_san_francisco,https://li.me,https://data.lime.bike/api/partners/v2/gbfs/san_francisco/gbfs.json,2.2,,,
 US,Lime San Jose,"San Jose, CA",lime_san_jose,https://www.li.me,https://data.lime.bike/api/partners/v2/gbfs/san_jose/gbfs.json,2.2,,,
-US,Lime Seattle,"Seattle, WA",lime_seattle,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/seattle/gbfs.json,1.0 ; 2.2,,,
+US,Lime Seattle,"Seattle, WA",lime_seattle,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/seattle/gbfs.json,2.2,,,
 US,Lime Washington DC,"Washington, DC",lime_washington_dc,https://www.li.me/,https://data.lime.bike/api/partners/v2/gbfs/washington_dc/gbfs.json,2.2,,,
 US,Lyft,"Washington, DC",lyft_dca,https://www.lyft.com/scooters/washington-dc,https://gbfs.lyft.com/gbfs/2.3/dca/gbfs.json,2.3,,,
 US,Lyft Scooters Chicago,"Chicago, IL",chicago,https://www.divvybikes.com,https://gbfs.divvybikes.com/gbfs/2.3/gbfs.json,2.3,,,
@@ -1299,4 +1299,3 @@ US,Veo Washington DC,"Washington, DC",Veo Mobility,https://www.veoride.com,https
 US,Veo Wichita,"Wichita, KS",Veo Mobility,https://www.veoride.com,https://cluster-prod.veoride.com/api/shares/name/wta/gbfs,2.2,,,
 US,WE-cycle,"Aspen, CO",we_cycle,https://www.we-cycle.org,https://aspen.publicbikesystem.net/customer/gbfs/v2/gbfs.json,1.1 ; 2.3,,,
 XK,Prishtina bike,Prishtina,nextbike_gs,https://www.prishtinabike.com/,https://gbfs.nextbike.net/maps/gbfs/v2/nextbike_gs/gbfs.json,2.3,,,
-


### PR DESCRIPTION
Reverts MobilityData/gbfs#805

My bad; I saw `"version": "1.0"` in the feed and assumed it was a valid GBFS v1 feed, but it's actually not conformant to v1.

For example: https://data.lime.bike/api/partners/v1/gbfs/seattle/station_status

```jsonc
{
    "last_updated": 1761008760,
    "ttl": 0,
    "version": "1.0",
    "data": {
        "stations": [
            {
                "station_id": "seattle",
                "num_vehicles_available": 11849, // should be num_bikes_available in v1
                "num_docks_available": 999999,
                "is_installed": true, // should be 1|0 in v1
                "is_renting": true,
                "is_returning": true,
                "last_reported": 1761008760
            }
        ]
    }
}
```