### PR TITLE
Update link for shared mobility resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Authentication Parameter Name | Conditionally REQUIRED | If authentication is re
 ## GBFS JSON Schemas
 Complete JSON schemas for each version of GBFS can be found [here](https://github.com/MobilityData/gbfs-json-schema).
 ## GBFS and Other Shared Mobility Resources
-Including APIs, datasets, validators, research, and software can be found [here](https://gbfs.org/toolbox/resources/).
+Including APIs, datasets, validators, research, and software can be found [here](https://gbfs.org/tools/).
 ## Relationship Between GBFS and MDS
 There are many similarities between GBFS and [MDS](https://github.com/openmobilityfoundation/mobility-data-specification) (Mobility Data Specification), however, their intended use cases are different. GBFS is a real-time or near real-time specification for public data primarily intended to provide transit advice through consumer-facing applications. MDS is not public data and is intended for use only by mobility regulators. Publishing a public GBFS feed is a [requirement](https://github.com/openmobilityfoundation/mobility-data-specification#gbfs-requirement) of all MDS compatible *Provider* APIs.
 ## Copyright


### PR DESCRIPTION
Fixes bad link to gbfs.org/tools in the README


#### **Is this a breaking change?**
- [ ] Yes 
- [x] No
- [ ] Unsure

#### **Which files are affected by this change?**
README