### PR TITLE
Revert "add Flamingo Christchurch (New Zealand)"

### DIFF
--- a/systems.csv
+++ b/systems.csv
@@ -868,7 +868,6 @@ NO,Voi Stavanger,Stavanger,voistavanger,https://www.voi.com/,https://api.entur.i
 NO,Voi Trondheim,Trondheim,voitrondheim,https://www.voi.com/,https://api.entur.io/mobility/v2/gbfs/v3/voitrondheim/gbfs,3.0,,,
 NO,Zeus Oslo,Oslo,zeus_oslo,https://zeusscooters.com/,https://zeus.city/api/v1/mds/gbfs/oslo/gbfs.json,2.2,,,
 NZ,Flamingo Auckland,Auckland,flamingo_auckland,https://rideflamingo.com,https://data.rideflamingo.com/gbfs/3/auckland/gbfs.json,2.3 ; 3.0,,,
-NZ,Flamingo Christchurch,Christchurch,flamingo_christchurch,https://rideflamingo.com,https://data.rideflamingo.com/gbfs/3/christchurch/gbfs.json,2.3 ; 3.0,,,
 NZ,Flamingo Dunedin,Dunedin,flamingo_dunedin,https://rideflamingo.com,https://data.rideflamingo.com/gbfs/3/dunedin/gbfs.json,2.3 ; 3.0,,,
 NZ,Flamingo Palmerston North,Palmerston North,flamingo_palmerston_north,https://rideflamingo.com,https://data.rideflamingo.com/gbfs/3/palmerston-north/gbfs.json,2.3 ; 3.0,,,
 NZ,Flamingo Porirua,"Porirua",flamingo_porirua,https://rideflamingo.com,https://data.rideflamingo.com/gbfs/3/porirua/gbfs.json,2.3 ; 3.0,,,


### PR DESCRIPTION
Reverts MobilityData/gbfs#812

Despite Flamingo showing Christchurch as a city on their website and having a valid feed, they don't actually operate in Christchurch according to the [Christchurch City Council](https://ccc.govt.nz/transport/getting-around/shared-scooters) - that and the feed having zero vehicles or stations. Apologies for the fuss!